### PR TITLE
feat: read user role from logto

### DIFF
--- a/router/member.go
+++ b/router/member.go
@@ -134,10 +134,13 @@ func (MemberRouter) CreateTokenViaLogtoToken(c *gin.Context) {
 		return nil, huma.Error422UnprocessableEntity(err.Error())
 	}
 
-	member.Role = service.MemberServiceApp.MapLogtoUserRole(logto_roles)
-	err = service.MemberServiceApp.UpdateMember(member)
-	if err != nil {
-		return nil, huma.Error422UnprocessableEntity("error at syncing member role" + err.Error())
+	mappedRole := service.MemberServiceApp.MapLogtoUserRole(logto_roles)
+	if mappedRole != member.Role && mappedRole != "" {
+		member.Role = mappedRole
+		err = service.MemberServiceApp.UpdateMember(member)
+		if err != nil {
+			return nil, huma.Error422UnprocessableEntity("error at syncing member role" + err.Error())
+		}
 	}
 
 	t, err := service.MemberServiceApp.CreateToken(member)

--- a/router/member.go
+++ b/router/member.go
@@ -131,7 +131,10 @@ func (MemberRouter) CreateTokenViaLogtoToken(c *gin.Context) {
 	}
 	logto_roles, err := service.LogtoServiceApp.FetchUserRole(logto_id, accessToken)
 	if err != nil {
-		return nil, huma.Error422UnprocessableEntity(err.Error())
+		c.AbortWithStatusJSON(util.
+			MakeServiceError(http.StatusUnprocessableEntity).
+			SetMessage("error at FetchLogtoToken" + err.Error()).
+			Build())
 	}
 
 	mappedRole := service.MemberServiceApp.MapLogtoUserRole(logto_roles)
@@ -139,7 +142,10 @@ func (MemberRouter) CreateTokenViaLogtoToken(c *gin.Context) {
 		member.Role = mappedRole
 		err = service.MemberServiceApp.UpdateMember(member)
 		if err != nil {
-			return nil, huma.Error422UnprocessableEntity("error at syncing member role" + err.Error())
+			c.AbortWithStatusJSON(util.
+				MakeServiceError(http.StatusUnprocessableEntity).
+				SetMessage("error at syncing member role" + err.Error()).
+				Build())
 		}
 	}
 

--- a/router/member.go
+++ b/router/member.go
@@ -129,6 +129,17 @@ func (MemberRouter) CreateTokenViaLogtoToken(c *gin.Context) {
 	if util.CheckError(c, err) {
 		return
 	}
+	logto_roles, err := service.LogtoServiceApp.FetchUserRole(logto_id, accessToken)
+	if err != nil {
+		return nil, huma.Error422UnprocessableEntity(err.Error())
+	}
+
+	member.Role = service.MemberServiceApp.MapLogtoUserRole(logto_roles)
+	err = service.MemberServiceApp.UpdateMember(member)
+	if err != nil {
+		return nil, huma.Error422UnprocessableEntity("error at syncing member role" + err.Error())
+	}
+
 	t, err := service.MemberServiceApp.CreateToken(member)
 	if util.CheckError(c, err) {
 		return

--- a/service/logto.go
+++ b/service/logto.go
@@ -158,4 +158,43 @@ func MakeLogtoService(endpoint string) LogtoService {
 	}
 }
 
+type LogtoUserRole struct {
+	TenantId    string `json:"tenantId"`
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	IsDefault   bool   `json:"isDefault"`
+}
+type FetchUserRoleResponse []LogtoUserRole
+
+func (l LogtoService) FetchUserRole(userId string, accessToken string) (FetchUserRoleResponse, error) {
+	userRoleURL, err := url.JoinPath(os.Getenv("LOGTO_ENDPOINT"), "/api/users/", userId, "/roles")
+	if err != nil {
+		return nil, err
+	}
+	req, _ := http.NewRequest("GET", userRoleURL, nil)
+	req.Header.Add("Authorization", "Bearer "+accessToken)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	rawBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Status != "200 OK" {
+		return nil, fmt.Errorf(string(rawBody))
+	}
+
+	var body FetchUserRoleResponse
+	if err := json.Unmarshal(rawBody, &body); err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
 var LogtoServiceApp LogtoService

--- a/service/member.go
+++ b/service/member.go
@@ -100,6 +100,18 @@ func (service *MemberService) CreateToken(member model.Member) (string, error) {
 // 	return nil
 // }
 
+func (service MemberService) MapLogtoUserRole(roles []LogtoUserRole) string {
+	role := ""
+	for _, r := range roles {
+		if r.Name == "Repair Admin" {
+			role = "admin"
+		} else if r.Name == "Repair Member" && role == "" {
+			role = "member"
+		}
+	}
+	return role
+}
+
 func (service *MemberService) UpdateMember(member model.Member) error {
 	exist, err := repo.ExistRole(member.Role)
 	if err != nil {

--- a/service/member_test.go
+++ b/service/member_test.go
@@ -1,0 +1,52 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/nbtca/saturday/service"
+)
+
+func TestMapLogtoUserRole(t *testing.T) {
+	tests := []struct {
+		name  string
+		roles []service.LogtoUserRole
+		want  string
+	}{
+		{
+			name: "Single Repair Admin",
+			roles: []service.LogtoUserRole{
+				{Name: "Repair Admin"},
+			},
+			want: "admin",
+		},
+		{
+			name: "Single Repair Member",
+			roles: []service.LogtoUserRole{
+				{Name: "Repair Member"},
+			},
+			want: "member",
+		},
+		{
+			name: "Repair Admin and Repair Member",
+			roles: []service.LogtoUserRole{
+				{Name: "Repair Admin"},
+				{Name: "Repair Member"},
+			},
+			want: "admin",
+		},
+		{
+			name:  "No Roles",
+			roles: []service.LogtoUserRole{},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := service.MemberService{}
+			if got := service.MapLogtoUserRole(tt.roles); got != tt.want {
+				t.Errorf("MapLogtoUserRole() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR allows user role to be managed from logto.

After the changes, role will be synced after user login if they have the logto role `Repair Admin` or `Repair Member`.

![截屏2024-12-24 22 09 33](https://github.com/user-attachments/assets/b464cdc2-7d3b-4dfc-9675-f2fa8e68f586)
![截屏2024-12-24 22 09 29](https://github.com/user-attachments/assets/e8f964a8-c755-4929-8e8f-7b832577dddc)
