### PR TITLE
feat: support create client using logto

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/nbtca/saturday/service"
 	"github.com/nbtca/saturday/util"
@@ -17,7 +18,12 @@ const (
 	Admin  Role = "admin"
 )
 
-func Auth(role ...Role) func(c *gin.Context) {
+type AuthContextUser struct {
+	UserInfo service.FetchUserInfoResponse
+	Role     []string
+}
+
+func Auth(acceptableRoles ...Role) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		token := c.GetHeader("Authorization")
 		if token == "" {
@@ -26,8 +32,38 @@ func Auth(role ...Role) func(c *gin.Context) {
 				Build())
 			return
 		}
+		// handel legacy jwt token
+		// this is currently used by wechat mini app
+		if len(strings.Split(token, ".")) > 1 {
+			tokenParsed, claims, err := util.ParseToken(token)
+			if err != nil || !tokenParsed.Valid {
+				c.AbortWithStatusJSON(util.MakeServiceError(http.StatusUnauthorized).
+					SetMessage("not authorized").
+					Build())
+				return
+			}
+			for _, roleObj := range acceptableRoles {
+				if string(roleObj) == claims.Role {
+					c.Set("id", claims.Who)
+					c.Set("member", claims.Member)
+					c.Set("role", claims.Role)
+					return
+				}
+			}
+			c.AbortWithStatusJSON(util.MakeServiceError(http.StatusUnauthorized).
+				SetMessage("not authorized").
+				Build())
+			return
+		}
+
 		// strip bearer
-		token = token[7:]
+		token, err := util.GetTokenString(token)
+		if err != nil {
+			c.AbortWithStatusJSON(util.MakeServiceError(http.StatusUnauthorized).
+				SetMessage("invalid token type").
+				Build())
+			return
+		}
 		userinfo, err := service.LogtoServiceApp.FetchUserInfo(token)
 		if err != nil {
 			c.AbortWithStatusJSON(util.MakeServiceError(http.StatusUnauthorized).
@@ -35,25 +71,41 @@ func Auth(role ...Role) func(c *gin.Context) {
 				Build())
 			return
 		}
+		// TODO this is used for backward compatibility, will only use userRoles in the future
 		var role string
+		userRoles := []string{"client"}
 		if slices.Contains(userinfo.Roles, "Repair Admin") {
+			userRoles = append(userRoles, "admin")
 			role = "admin"
-		} else if slices.Contains(userinfo.Roles, "Repair Member") {
-			role = "member"
 		}
-		if role != "" {
-			member, err := service.MemberServiceApp.GetMemberByLogtoId(userinfo.Sub)
-			if err != nil {
-				c.AbortWithStatusJSON(util.MakeServiceError(http.StatusUnauthorized).
-					SetMessage("not authorized").
-					Build())
+		if slices.Contains(userinfo.Roles, "Repair Member") {
+			userRoles = append(userRoles, "member")
+			if role == "" {
+				role = "member"
 			}
-			c.Set("id", member.MemberId)
-			c.Set("member", member)
-			c.Set("role", role)
-			c.Set("user", userinfo)
-			return
 		}
+		for _, r := range acceptableRoles {
+			if slices.Contains(userRoles, string(r)) {
+				member, err := service.MemberServiceApp.GetMemberByLogtoId(userinfo.Sub)
+				if err != nil {
+					c.AbortWithStatusJSON(util.MakeServiceError(http.StatusUnauthorized).
+						SetMessage("not authorized").
+						Build())
+				}
+				user := AuthContextUser{
+					Role:     userRoles,
+					UserInfo: userinfo,
+				}
+				c.Set("id", member.MemberId)
+				c.Set("member", member)
+				c.Set("role", role)
+				c.Set("user", user)
+				return
+			}
+		}
+		c.AbortWithStatusJSON(util.MakeServiceError(http.StatusUnauthorized).
+			SetMessage("not authorized").
+			Build())
 	}
 }
 

--- a/migrations/000002_add_logto_id_to_client.down.sql
+++ b/migrations/000002_add_logto_id_to_client.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.client
+DROP COLUMN logto_id;

--- a/migrations/000002_add_logto_id_to_client.up.sql
+++ b/migrations/000002_add_logto_id_to_client.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.client
+ADD COLUMN logto_id character varying(50) DEFAULT ''::character varying;

--- a/model/client.go
+++ b/model/client.go
@@ -3,6 +3,7 @@ package model
 type Client struct {
 	ClientId    int64  `json:"clientId" db:"client_id"`
 	OpenId      string `json:"openid"`
+	LogtoId 		string `json:"logtoId" db:"logto_id"`
 	GmtCreate   string `json:"gmtCreate" db:"gmt_create"`
 	GmtModified string `json:"gmtModified" db:"gmt_modified"`
 }

--- a/repo/client.go
+++ b/repo/client.go
@@ -22,13 +22,26 @@ func GetClientByOpenId(openId string) (model.Client, error) {
 	return client, nil
 }
 
+func GetClientByLogtoId(logtoId string) (model.Client, error) {
+	statement, args, _ := sq.Select("*").From("client").Where(squirrel.Eq{"logto_id": logtoId}).ToSql()
+	client := model.Client{}
+	if err := db.Get(&client, statement, args...); err != nil {
+		if err == sql.ErrNoRows {
+			return model.Client{}, nil
+		}
+		return model.Client{}, nil
+	}
+	return client, nil
+}
+
+
 func CreateClient(client *model.Client) error {
 	client.GmtCreate = util.GetDate()
 	client.GmtModified = util.GetDate()
-	sql, args, _ := sq.Insert("client").Columns("openid", "gmt_create", "gmt_modified").
-		Values(client.OpenId, time.Now(), time.Now()).ToSql()
+	sql, args, _ := sq.Insert("client").Columns("openid", "logto_id", "gmt_create", "gmt_modified").
+		Values(client.OpenId, client.LogtoId, time.Now(), time.Now()).ToSql()
 	var id int64
-	err := db.QueryRow(sql+"RETURNING id", args...).Scan(&id)
+	err := db.QueryRow(sql+"RETURNING client_id", args...).Scan(&id)
 	if err != nil {
 		return err
 	}

--- a/router/main.go
+++ b/router/main.go
@@ -101,6 +101,8 @@ func SetupRouter() *gin.Engine {
 		Tags:        []string{"Client", "Public"},
 	}, ClientRouterApp.CreateTokenViaWeChat)
 
+	Router.POST("/clients/token/logto", middleware.Auth("client"), ClientRouterApp.CreateTokenViaLogto)
+
 	huma.Register(api, huma.Operation{
 		OperationID: "get-public-event-by-id",
 		Method:      http.MethodGet,

--- a/service/client.go
+++ b/service/client.go
@@ -11,7 +11,7 @@ import (
 type ClientService struct {
 }
 
-func (service ClientService) CreateTokenViaWechat(client model.Client) (string, error) {
+func (service ClientService) CreateClientToken(client model.Client) (string, error) {
 	res, err := util.CreateToken(util.Payload{Who: fmt.Sprint(client.ClientId), Role: "client"})
 	return res, err
 }
@@ -24,8 +24,25 @@ func (service ClientService) GetClientByOpenId(openId string) (model.Client, err
 	return client, nil
 }
 
+func (service ClientService) GetClientByLogtoId(logtoId string) (model.Client, error) {
+	client, err := repo.GetClientByLogtoId(logtoId)
+	if err != nil {
+		return model.Client{}, err
+	}
+	return client, nil
+}
+
 func (service ClientService) CreateClientByOpenId(openId string) (model.Client, error) {
 	client := model.Client{OpenId: openId}
+	err := repo.CreateClient(&client)
+	if err != nil {
+		return model.Client{}, err
+	}
+	return client, nil
+}
+
+func (service ClientService) CreateClientByLogtoId(logtoId string) (model.Client, error) {
+	client := model.Client{LogtoId: logtoId}
 	err := repo.CreateClient(&client)
 	if err != nil {
 		return model.Client{}, err


### PR DESCRIPTION
Add API `POST /clients/token/logto` for creating client JWT token via Logto access_token'

```
POST  {{base_url}}/clients/token/logto
Content-Type: application/json
Authorization: {{access_token}}

{
  "token": ""
  "clientId": 1,
  "openid": "",
  "logtoId": "",
  "gmtCreate": "",
  "gmtModified": ""
}
```