### PR TITLE
feat: add event size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/qustavo/sqlhooks/v2 v2.1.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -32,6 +33,7 @@ require (
 	github.com/bytedance/sonic/loader v0.2.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.5 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -43,6 +45,7 @@ require (
 	github.com/kr/text v0.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0 // indirect

--- a/migrations/000005_add_size_to_event.down.sql
+++ b/migrations/000005_add_size_to_event.down.sql
@@ -1,0 +1,21 @@
+ALTER TABLE public.event
+DROP COLUMN size;
+
+CREATE OR REPLACE VIEW public.event_view AS
+ SELECT event.event_id,
+    event.client_id,
+    event.model,
+    event.phone,
+    event.qq,
+    event.contact_preference,
+    event.problem,
+    event.member_id,
+    event.closed_by,
+    event.gmt_create,
+    event.gmt_modified,
+    COALESCE(event_status.status, ''::character varying) AS status,
+    event.github_issue_id,
+    event.github_issue_number
+   FROM ((public.event
+     LEFT JOIN public.event_event_status_relation ON ((event.event_id = event_event_status_relation.event_id)))
+     LEFT JOIN public.event_status ON ((event_event_status_relation.event_status_id = event_status.event_status_id)));

--- a/migrations/000005_add_size_to_event.up.sql
+++ b/migrations/000005_add_size_to_event.up.sql
@@ -1,0 +1,24 @@
+ALTER TABLE public.event
+ADD COLUMN size character varying(50) DEFAULT ''::character varying NOT NULL;
+
+COMMENT ON COLUMN public.event.size IS '工作量';
+
+CREATE OR REPLACE VIEW public.event_view AS
+ SELECT event.event_id,
+    event.client_id,
+    event.model,
+    event.phone,
+    event.qq,
+    event.contact_preference,
+    event.problem,
+    event.member_id,
+    event.closed_by,
+    event.gmt_create,
+    event.gmt_modified,
+    event.size,
+    COALESCE(event_status.status, ''::character varying) AS status,
+    event.github_issue_id,
+    event.github_issue_number
+   FROM ((public.event
+     LEFT JOIN public.event_event_status_relation ON ((event.event_id = event_event_status_relation.event_id)))
+     LEFT JOIN public.event_status ON ((event_event_status_relation.event_status_id = event_status.event_status_id)));

--- a/model/dto/event.go
+++ b/model/dto/event.go
@@ -18,12 +18,13 @@ type UpdateRequest struct {
 	Problem           string `json:"problem" db:"problem" binding:"omitempty,max=1000"`
 	Model             string `json:"model" binding:"omitempty,max=40"`
 	ContactPreference string `json:"contactPreference" db:"contact_preference" `
+	Size              string `json:"size" db:"size" `
 }
 type CreateEventRequest struct {
 	ClientId          int64  `json:"clientId" db:"client_id"`
 	Model             string `json:"model" binding:"omitempty,max=40"`
-	Phone             string `json:"phone" binding:"omitempty,len=11,numeric"`
+	Phone             string `json:"phone" binding:"required,omitempty,len=11,numeric"`
 	QQ                string `json:"qq" binding:"omitempty,min=5,max=20,numeric"`
 	ContactPreference string `json:"contactPreference" db:"contact_preference" `
-	Problem           string `json:"problem" db:"problem" binding:"omitempty,max=1000"`
+	Problem           string `json:"problem" db:"problem" binding:"required,omitempty,max=1000"`
 }

--- a/model/event.go
+++ b/model/event.go
@@ -23,6 +23,7 @@ type Event struct {
 	ClosedBy          string        `json:"closedById" db:"closed_by"`
 	ClosedByMember    *PublicMember `json:"closedBy" db:"-"`
 	Status            string        `json:"status"`
+	Size              string        `json:"size"`
 	Logs              []EventLog    `json:"logs"`
 	GmtCreate         string        `json:"gmtCreate" db:"gmt_create"`
 	GmtModified       string        `json:"gmtModified" db:"gmt_modified"`
@@ -77,6 +78,7 @@ type PublicEvent struct {
 	ClosedByMember *PublicMember `json:"closedBy"`
 	Status         string        `json:"status"`
 	Logs           []EventLog    `json:"logs"`
+	Size           string        `json:"size"`
 	GmtCreate      string        `json:"gmtCreate" db:"gmt_create"`
 	GmtModified    string        `json:"gmtModified" db:"gmt_modified"`
 }
@@ -93,6 +95,7 @@ func CreatePublicEvent(e Event) PublicEvent {
 		ClosedByMember: e.ClosedByMember,
 		Status:         e.Status,
 		Logs:           e.Logs,
+		Size:           e.Size,
 		GmtCreate:      e.GmtCreate,
 		GmtModified:    e.GmtModified,
 	}

--- a/repo/event.go
+++ b/repo/event.go
@@ -11,7 +11,7 @@ import (
 )
 
 var eventFields = []string{"event_id", "client_id", "model", "phone", "qq", "contact_preference",
-	"problem", "member_id", "closed_by", "status", "gmt_create", "gmt_modified", "status", "github_issue_id", "github_issue_number"}
+	"problem", "member_id", "closed_by", "status", "size", "gmt_create", "gmt_modified", "status", "github_issue_id", "github_issue_number"}
 
 var EventLogFields = []string{"event_log_id", "description", "gmt_create", "member_id", "action"}
 
@@ -63,7 +63,7 @@ func GetEventById(id int64) (model.Event, error) {
 	joinEvent := JoinEvent{}
 	if err := conn.Get(&joinEvent, getEventSql, getEventArgs...); err != nil {
 		if err == sql.ErrNoRows {
-			return model.Event{}, nil
+			return model.Event{}, err
 		}
 		conn.Rollback()
 		return model.Event{}, err
@@ -152,6 +152,7 @@ func UpdateEvent(event *model.Event, eventLog *model.EventLog) error {
 		Set("qq", event.QQ).
 		Set("contact_preference", event.ContactPreference).
 		Set("problem", event.Problem).
+		Set("size", event.Size).
 		Set("member_id", event.MemberId).
 		Set("closed_by", event.ClosedBy)
 	if event.GithubIssueId.Valid {

--- a/repo/event.go
+++ b/repo/event.go
@@ -145,6 +145,15 @@ func GetClientEvents(f EventFilter, clientId int64) ([]model.Event, error) {
 	return getEvents(f, squirrel.Eq{"e.client_id": clientId})
 }
 
+func UpdateEventSize(eventId int64, size string) error {
+	builder := sq.Update("event").
+		Set("size", size).
+		Where(squirrel.Eq{"event_id": eventId})
+	sql, args, _ := builder.ToSql()
+	_, err := db.Exec(sql, args...)
+	return err
+}
+
 func UpdateEvent(event *model.Event, eventLog *model.EventLog) error {
 	builder := sq.Update("event").
 		Set("model", event.Model).

--- a/router/event.go
+++ b/router/event.go
@@ -249,6 +249,9 @@ func (er EventRouter) Update(c *gin.Context) {
 	if req.ContactPreference != "" {
 		event.ContactPreference = req.ContactPreference
 	}
+	if req.Size != "" {
+		event.Size = req.Size
+	}
 	if err := service.EventServiceApp.Act(&event, identity, util.Update); util.CheckError(c, err) {
 		return
 	}

--- a/service/event.go
+++ b/service/event.go
@@ -400,4 +400,12 @@ func (service EventService) Act(event *model.Event, identity model.Identity, act
 	return nil
 }
 
+func ValidateEventSize(size string) error {
+	// size can be one of xs,s,m,l,xl
+	if size != "xs" && size != "s" && size != "m" && size != "l" && size != "xl" {
+		return fmt.Errorf("size %s is not valid", size)
+	}
+	return nil
+}
+
 var EventServiceApp = EventService{}

--- a/service/webhook.go
+++ b/service/webhook.go
@@ -28,8 +28,25 @@ func MakeGithubWebHook(secret string) (*GithubWebHook, error) {
 	return &GithubWebHook{hook: hook}, nil
 }
 
-// - accept repair event when some one is assigned to the issue
-// - close repair whe issue when rep
+func ExtractCommand(comment string) (string, error) {
+	re := regexp.MustCompile(`@nbtca-bot\s+(\w+)`)
+	match := re.FindStringSubmatch(comment)
+	if len(match) < 2 {
+		return "", fmt.Errorf("command not found")
+	}
+	return match[1], nil
+}
+
+func ExtractSizeLabel(label string) (string, error) {
+	re := regexp.MustCompile(`size:\s*(\w+)`)
+	match := re.FindStringSubmatch(label)
+	if len(match) < 2 {
+		return "", fmt.Errorf("size label not found")
+	}
+	err := ValidateEventSize(match[1])
+	return match[1], err
+}
+
 func (gh *GithubWebHook) Handle(request *http.Request) error {
 	payload, err := gh.hook.Parse(
 		request,
@@ -41,111 +58,166 @@ func (gh *GithubWebHook) Handle(request *http.Request) error {
 	if err != nil {
 		return err
 	}
-	switch payload.(type) {
+
+	switch payload := payload.(type) {
+	case github.IssuesPayload:
+		return gh.handleIssuesPayload(payload)
 	case github.IssueCommentPayload:
-		comment := payload.(github.IssueCommentPayload)
-
-		match := regexp.MustCompile(`@nbtca-bot\s+(\w+)`).FindStringSubmatch(comment.Comment.Body)
-		if len(match) < 2 {
-			return nil
-		}
-		action := match[1]
-		util.Logger.Debugf("event action from webhook: %s", action)
-
-		event, err := repo.GetEventByIssueId(comment.Issue.ID)
-		if err != nil {
-			return err
-		}
-		if event.EventId == 0 {
-			return nil
-		}
-		member, err := MemberServiceApp.GetMemberByGithubId(strconv.FormatInt(comment.Sender.ID, 10))
-		if err != nil {
-			return err
-		}
-		if member.MemberId == "" {
-			return util.MakeValidationError("member not found", nil)
-		}
-		util.Logger.Tracef("member found: %v", member)
-		logtoUserRoleResponse, err := LogtoServiceApp.FetchUserRole(member.LogtoId)
-		if err != nil {
-			return fmt.Errorf("logto user role error %v", err)
-		}
-		identity := model.Identity{
-			Id:     member.MemberId,
-			Member: member,
-			Role:   MemberServiceApp.MapLogtoUserRole(logtoUserRoleResponse),
-		}
-		util.Logger.Tracef("using identity %v", identity)
-
-		var readyForReviewLabel = "ready for review"
-		var acceptedLabel = "accepted"
-
-		if comment.Action == "created" && action == "accept" {
-			err := EventServiceApp.Act(&event, identity, util.Accept)
-			if err != nil {
-				return err
-			}
-			user, _, err := util.GetUserById(comment.Sender.ID)
-			if err != nil {
-				return err
-			}
-			_, _, err = util.AddIssueAssignee(int(comment.Issue.Number), []string{*user.Login})
-			if err != nil {
-				return err
-			}
-
-			_, _, err = util.AddIssueLabels(int(comment.Issue.Number), []string{acceptedLabel})
-			if err != nil {
-				return err
-			}
-		}
-		if action == "commit" {
-			re := regexp.MustCompile(`@nbtca-bot\s+\w+`)
-			text := comment.Comment.Body
-			cleaned := re.ReplaceAllString(text, "")
-			cleaned = strings.TrimSpace(cleaned)
-			if event.Status == util.Accepted {
-				if err := EventServiceApp.Act(&event, identity, util.Commit, cleaned); err != nil {
-					return err
-				}
-
-				_, _, err := util.AddIssueLabels(int(comment.Issue.Number), []string{readyForReviewLabel})
-				if err != nil {
-					return err
-				}
-				return nil
-			}
-
-			if event.Status == util.Committed {
-				return EventServiceApp.Act(&event, identity, util.AlterCommit, cleaned)
-			}
-
-		}
-
-		if comment.Action == "created" && action == "reject" {
-			err := EventServiceApp.Act(&event, identity, util.Reject)
-			if err != nil {
-				return err
-			}
-			_, err = util.RemoveIssueLabel(int(comment.Issue.Number), readyForReviewLabel)
-			return err
-		}
-
-		if comment.Action == "created" && action == "close" {
-			return EventServiceApp.Act(&event, identity, util.Close)
-		}
-
-		if comment.Action == "created" && action == "drop" {
-			err := EventServiceApp.Act(&event, identity, util.Drop)
-			if err != nil {
-				return err
-			}
-			_, err = util.RemoveIssueLabel(int(comment.Issue.Number), acceptedLabel)
-			return err
-		}
+		return gh.handleIssueCommentPayload(payload)
 	}
 	return nil
+}
+
+func (gh *GithubWebHook) handleIssuesPayload(issue github.IssuesPayload) error {
+	if issue.Action != "labeled" {
+		return gh.handleIssueWithoutLabel(issue)
+	}
+	return gh.handleIssueWithLabel(issue)
+}
+
+func (gh *GithubWebHook) handleIssueWithoutLabel(issue github.IssuesPayload) error {
+	size := ""
+	for _, label := range issue.Issue.Labels {
+		size, _ = ExtractSizeLabel(label.Name)
+	}
+	if size != "" {
+		return nil
+	}
+	event, err := repo.GetEventByIssueId(issue.Issue.ID)
+	if err != nil || event.EventId == 0 {
+		return nil
+	}
+	return repo.UpdateEventSize(event.EventId, "")
+}
+
+func (gh *GithubWebHook) handleIssueWithLabel(issue github.IssuesPayload) error {
+	if issue.Label.ID == 0 {
+		util.Logger.Debugf("issue label not found")
+		return nil
+	}
+	size, err := ExtractSizeLabel(issue.Label.Name)
+	if err != nil {
+		util.Logger.Debugf(err.Error())
+		return err
+	}
+	util.Logger.Debugf("size label found: %s", size)
+	event, err := repo.GetEventByIssueId(issue.Issue.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get event by issue id: %v", err)
+	}
+	if err := repo.UpdateEventSize(event.EventId, size); err != nil {
+		return fmt.Errorf("failed to update event size: %v", err)
+	}
+	return nil
+}
+
+func (gh *GithubWebHook) handleIssueCommentPayload(comment github.IssueCommentPayload) error {
+	command, err := ExtractCommand(comment.Comment.Body)
+	if err != nil {
+		return err
+	}
+	util.Logger.Debugf("command from github webhook: %s", command)
+
+	event, err := repo.GetEventByIssueId(comment.Issue.ID)
+	if err != nil {
+		return err
+	}
+	if event.EventId == 0 {
+		return nil
+	}
+	member, err := MemberServiceApp.GetMemberByGithubId(strconv.FormatInt(comment.Sender.ID, 10))
+	if err != nil {
+		return err
+	}
+	if member.MemberId == "" {
+		return util.MakeValidationError("member not found", nil)
+	}
+	util.Logger.Tracef("member found: %v", member)
+	logtoUserRoleResponse, err := LogtoServiceApp.FetchUserRole(member.LogtoId)
+	if err != nil {
+		return fmt.Errorf("logto user role error %v", err)
+	}
+	identity := model.Identity{
+		Id:     member.MemberId,
+		Member: member,
+		Role:   MemberServiceApp.MapLogtoUserRole(logtoUserRoleResponse),
+	}
+	util.Logger.Tracef("using identity %v", identity)
+
+	return gh.processCommand(comment, command, event, identity)
+}
+
+func (gh *GithubWebHook) processCommand(comment github.IssueCommentPayload, command string, event model.Event, identity model.Identity) error {
+	var readyForReviewLabel = "ready for review"
+	var acceptedLabel = "accepted"
+
+	switch {
+	case comment.Action == "created" && command == "accept":
+		return gh.handleAcceptCommand(comment, event, identity, acceptedLabel)
+	case command == "commit":
+		return gh.handleCommitCommand(comment, event, identity, readyForReviewLabel)
+	case comment.Action == "created" && command == "reject":
+		return gh.handleRejectCommand(comment, event, identity, readyForReviewLabel)
+	case comment.Action == "created" && command == "close":
+		return EventServiceApp.Act(&event, identity, util.Close)
+	case comment.Action == "created" && command == "drop":
+		return gh.handleDropCommand(comment, event, identity, acceptedLabel)
+	}
+	return nil
+}
+
+func (gh *GithubWebHook) handleAcceptCommand(comment github.IssueCommentPayload, event model.Event, identity model.Identity, acceptedLabel string) error {
+	err := EventServiceApp.Act(&event, identity, util.Accept)
+	if err != nil {
+		return err
+	}
+	user, _, err := util.GetUserById(comment.Sender.ID)
+	if err != nil {
+		return err
+	}
+	_, _, err = util.AddIssueAssignee(int(comment.Issue.Number), []string{*user.Login})
+	if err != nil {
+		return err
+	}
+	_, _, err = util.AddIssueLabels(int(comment.Issue.Number), []string{acceptedLabel})
+	return err
+}
+
+func (gh *GithubWebHook) handleCommitCommand(comment github.IssueCommentPayload, event model.Event, identity model.Identity, readyForReviewLabel string) error {
+	re := regexp.MustCompile(`@nbtca-bot\s+\w+`)
+	text := comment.Comment.Body
+	cleaned := re.ReplaceAllString(text, "")
+	cleaned = strings.TrimSpace(cleaned)
+
+	switch event.Status {
+	case util.Accepted:
+		if err := EventServiceApp.Act(&event, identity, util.Commit, cleaned); err != nil {
+			return err
+		}
+		_, _, err := util.AddIssueLabels(int(comment.Issue.Number), []string{readyForReviewLabel})
+		return err
+	case util.Committed:
+		return EventServiceApp.Act(&event, identity, util.AlterCommit, cleaned)
+	}
+	return nil
+}
+
+func (gh *GithubWebHook) handleRejectCommand(comment github.IssueCommentPayload, event model.Event, identity model.Identity, readyForReviewLabel string) error {
+	err := EventServiceApp.Act(&event, identity, util.Reject)
+	if err != nil {
+		return err
+	}
+	_, err = util.RemoveIssueLabel(int(comment.Issue.Number), readyForReviewLabel)
+	return err
+}
+
+func (gh *GithubWebHook) handleDropCommand(comment github.IssueCommentPayload, event model.Event, identity model.Identity, acceptedLabel string) error {
+	err := EventServiceApp.Act(&event, identity, util.Drop)
+	if err != nil {
+		return err
+	}
+	_, err = util.RemoveIssueLabel(int(comment.Issue.Number), acceptedLabel)
+	return err
 }
 
 type LogtoWebHook struct {

--- a/service/webhook_test.go
+++ b/service/webhook_test.go
@@ -1,0 +1,26 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/nbtca/saturday/service"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGithubWebHook_ExtractCommand(t *testing.T) {
+	comment := "@nbtca-bot accept"
+	command, err := service.ExtractCommand(comment)
+
+	// Assert the command is correctly extracted
+	assert.NoError(t, err)
+	assert.Equal(t, "accept", command)
+}
+
+func TestGithubWebHook_ExtractSizeLabel(t *testing.T) {
+	label := "size:m"
+	size, err := service.ExtractSizeLabel(label)
+
+	// Assert the size label is correctly extracted
+	assert.NoError(t, err)
+	assert.Equal(t, "m", size)
+}

--- a/util/github.go
+++ b/util/github.go
@@ -26,6 +26,22 @@ func CreateIssueComment(number int, issueComment *github.IssueComment) (*github.
 	return ghClient.Issues.CreateComment(context.Background(), owner, repo, number, issueComment)
 }
 
+func GetIssue(number int) (*github.Issue, *github.Response, error) {
+	return ghClient.Issues.Get(context.Background(), owner, repo, number)
+}
+
+func EditIssue(number int, issue *github.IssueRequest) (*github.Issue, *github.Response, error) {
+	return ghClient.Issues.Edit(context.Background(), owner, repo, number, issue)
+}
+
+func ReactToIssueComment(commentId int64, reaction string) (*github.Reaction, *github.Response, error) {
+	return ghClient.Reactions.CreateIssueCommentReaction(context.Background(), owner, repo, commentId, reaction)
+}
+
+func EditIssueComment(issueComment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	return ghClient.Issues.EditComment(context.Background(), owner, repo, issueComment.GetID(), issueComment)
+}
+
 func CloseIssue(number int, stateReason string) (*github.Issue, *github.Response, error) {
 	state := "closed"
 	return ghClient.Issues.Edit(context.Background(), owner, repo, number, &github.IssueRequest{


### PR DESCRIPTION
- Add event size field
- Sync event size with GitHub Issue tags (for example: size:s)
- Improve Github Issue integration: add event status table in issue description, add reaction to bot command...

![截屏2025-05-08 23 27 01](https://github.com/user-attachments/assets/30d9b281-bb1c-402c-9979-312530346c42)
![截屏2025-05-08 23 27 14](https://github.com/user-attachments/assets/ebfd4f18-3027-4513-94d7-9b953f338827)

resolve #184 