### PR TITLE
fix: correct parameter order in email notification template

### DIFF
--- a/service/event.go
+++ b/service/event.go
@@ -295,7 +295,7 @@ func (service EventService) SendActionNotifyViaMail(event *model.Event, eventLog
 		<div style="padding-top:10px;">
   		<a href="http://github.com/nbtca/repair-tickets/issues/%v">在 nbtca/repair-tickets 中处理</a>
 		</div>
-			`, event.Status, event.Problem, event.Model, event.Phone, event.QQ, event.GmtCreate, issueNumber))
+			`, event.Status, event.Problem, event.Model, event.GmtCreate, event.Phone, event.QQ, issueNumber))
 
 		if err := util.SendMail(m); err != nil {
 			return util.MakeInternalServerError().SetMessage("fail on mail")


### PR DESCRIPTION
Fixed critical bug where email notification fields were displaying incorrect data due to parameter order mismatch in fmt.Sprintf:
- Creation time was showing phone number
- Phone field was showing QQ number
- QQ field was showing creation time

Changed argument order from (Status, Problem, Model, Phone, QQ, GmtCreate) to (Status, Problem, Model, GmtCreate, Phone, QQ) to match the HTML template field order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)