### PR TITLE
Fix export filtering for same-day date ranges

### DIFF
--- a/repo/event.go
+++ b/repo/event.go
@@ -152,7 +152,8 @@ func GetClientEvents(f EventFilter, clientId int64) ([]model.Event, error) {
 
 func GetClosedEventsByTimeRange(f EventFilter, startTime, endTime string) ([]JoinEvent, error) {
 	stat := getEventStatement().
-		Where("DATE(e.gmt_create) BETWEEN DATE(?) AND DATE(?)", startTime, endTime).
+		Where("e.gmt_create >= DATE(?)", startTime).
+		Where("e.gmt_create < DATE(?) + INTERVAL '1 day'", endTime).
 		Where("e.status = ?", util.Closed).
 		Where("e.closed_by != ''")
 	getEventSql, getEventArgs, _ := stat.Offset(f.Offset).Limit(f.Limit).ToSql()


### PR DESCRIPTION
When exporting events with the same start and end date (e.g., 10/18 to 10/18), the BETWEEN clause with timestamps was only matching events created at exactly midnight, excluding events created later in the day.

Changed the query to use DATE() function to compare only the date portion, ensuring all events from the selected date are included in the export.

Fixes issue where selecting 10/18 to 10/18 returned empty results, but 10/17 to 10/19 correctly returned 10/18 events.