### PR TITLE
feat: add pagination metadata to event API responses via headers

### DIFF
--- a/service/event.go
+++ b/service/event.go
@@ -80,7 +80,7 @@ func (service EventService) ExportEventToXlsx(f repo.EventFilter, startTime, end
 		if sizeHour > 0 {
 			group.Hour += sizeHour
 		} else {
-			group.Hour += 0.5 // Default increment for unknown sizes	
+			group.Hour += 0.5 // Default increment for unknown sizes
 		}
 		if group.Hour > MaxHour {
 			group.Hour = MaxHour // Cap the hour count at MaxHour
@@ -182,6 +182,42 @@ func (service EventService) GetPublicEvents(f repo.EventFilter) ([]model.PublicE
 		publicEvents[i] = model.CreatePublicEvent(v)
 	}
 	return publicEvents, nil
+}
+
+func (service EventService) GetPublicEventsWithCount(f repo.EventFilter) ([]model.PublicEvent, int64, error) {
+	events, err := service.GetPublicEvents(f)
+	if err != nil {
+		return nil, 0, err
+	}
+	count, err := repo.CountEvents(f)
+	if err != nil {
+		return nil, 0, err
+	}
+	return events, count, nil
+}
+
+func (service EventService) GetMemberEventsWithCount(f repo.EventFilter, memberId string) ([]model.Event, int64, error) {
+	events, err := repo.GetMemberEvents(f, memberId)
+	if err != nil {
+		return nil, 0, err
+	}
+	count, err := repo.CountMemberEvents(f, memberId)
+	if err != nil {
+		return nil, 0, err
+	}
+	return events, count, nil
+}
+
+func (service EventService) GetClientEventsWithCount(f repo.EventFilter, clientId int64) ([]model.Event, int64, error) {
+	events, err := repo.GetClientEvents(f, clientId)
+	if err != nil {
+		return nil, 0, err
+	}
+	count, err := repo.CountClientEvents(f, clientId)
+	if err != nil {
+		return nil, 0, err
+	}
+	return events, count, nil
 }
 
 func (service EventService) CreateEvent(event *model.Event) error {

--- a/util/request.go
+++ b/util/request.go
@@ -51,9 +51,33 @@ func GetIdentity(c *gin.Context) model.Identity {
 }
 
 type CommonResponse[T any] struct {
-	Body T
+	Body       T
+	Total      *int64  `header:"X-Total-Count" doc:"Total number of items"`
+	Offset     *uint64 `header:"X-Offset" doc:"Offset for pagination"`
+	Limit      *uint64 `header:"X-Limit" doc:"Limit for pagination"`
+	Page       *int64  `header:"X-Page" doc:"Current page number (1-indexed)"`
+	TotalPages *int64  `header:"X-Total-Pages" doc:"Total number of pages"`
 }
 
 func MakeCommonResponse[T any](body T) *CommonResponse[T] {
 	return &CommonResponse[T]{Body: body}
+}
+
+func MakePaginatedResponse[T any](body T, total int64, offset, limit uint64) *CommonResponse[T] {
+	page := int64(1)
+	if limit > 0 {
+		page = int64(offset/limit) + 1
+	}
+	totalPages := int64(0)
+	if limit > 0 {
+		totalPages = (total + int64(limit) - 1) / int64(limit)
+	}
+	return &CommonResponse[T]{
+		Body:       body,
+		Total:      &total,
+		Offset:     &offset,
+		Limit:      &limit,
+		Page:       &page,
+		TotalPages: &totalPages,
+	}
 }


### PR DESCRIPTION
This commit adds pagination-related fields to GET /event API endpoints while maintaining full backward compatibility by using HTTP headers:

Changes:
- Added pagination response headers to CommonResponse: X-Total-Count, X-Offset, X-Limit, X-Page, and X-Total-Pages
- Created MakePaginatedResponse helper function in util/request.go
- Added count functions in repo layer: CountEvents, CountMemberEvents, CountClientEvents
- Added service methods that return both events and counts: GetPublicEventsWithCount, GetMemberEventsWithCount, GetClientEventsWithCount
- Updated router handlers to use paginated responses: GetPublicEventByPage, GetMemberEventByPage, GetClientEventByPage

Backward Compatibility:
- JSON response body remains unchanged (returns array directly)
- Pagination metadata is provided via standard HTTP headers
- Existing clients can ignore the headers and continue to work
- New clients can read headers for pagination information

Example response:
HTTP Headers:
  X-Total-Count: 100 X-Offset: 0 X-Limit: 50 X-Page: 1 X-Total-Pages: 2

JSON Body:
  [{...}, {...}]