### PR TITLE
Update public event page filter and status

### DIFF
--- a/repo/event.go
+++ b/repo/event.go
@@ -108,13 +108,13 @@ func GetEventByIssueId(issueId int64) (model.Event, error) {
 type EventFilter struct {
 	Offset uint64
 	Limit  uint64
-	Status string
+	Status []string
 	Order  string
 }
 
 func getJoinEvents(f EventFilter, conditions ...squirrel.Eq) ([]JoinEvent, error) {
 	stat := getEventStatement()
-	if f.Status != "" {
+	if len(f.Status) > 0 {
 		stat = stat.Where(squirrel.Eq{"e.status": f.Status})
 	}
 	for _, condition := range conditions {
@@ -152,7 +152,7 @@ func GetClientEvents(f EventFilter, clientId int64) ([]model.Event, error) {
 
 func countEvents(f EventFilter, conditions ...squirrel.Eq) (int64, error) {
 	stat := sq.Select("COUNT(*)").From("event_view as e")
-	if f.Status != "" {
+	if len(f.Status) > 0 {
 		stat = stat.Where(squirrel.Eq{"e.status": f.Status})
 	}
 	for _, condition := range conditions {

--- a/router/event.go
+++ b/router/event.go
@@ -31,8 +31,8 @@ func (EventRouter) GetPublicEventById(c context.Context, input *struct {
 
 func (EventRouter) GetPublicEventByPage(c context.Context, input *struct {
 	dto.PageRequest
-	Status string `query:"status"`
-	Order  string `query:"order" default:"ASC"`
+	Status []string `query:"status"`
+	Order  string   `query:"order" default:"ASC"`
 }) (*util.CommonResponse[[]model.PublicEvent], error) {
 	filter := repo.EventFilter{
 		Offset: input.Offset,
@@ -76,10 +76,14 @@ func (EventRouter) GetMemberEventByPage(ctx context.Context, input *GetMemberEve
 	if err != nil {
 		return nil, err
 	}
+	var status []string
+	if input.Status != "" {
+		status = []string{input.Status}
+	}
 	filter := repo.EventFilter{
 		Offset: input.Offset,
 		Limit:  input.Limit,
-		Status: input.Status,
+		Status: status,
 		Order:  input.Order,
 	}
 	events, count, err := service.EventServiceApp.GetMemberEventsWithCount(filter, auth.ID)
@@ -97,10 +101,14 @@ func (EventRouter) ExportEventsToXlsx(ctx context.Context, input *ExportEventsTo
 		return nil, err
 	}
 
+	var status []string
+	if input.Status != "" {
+		status = []string{input.Status}
+	}
 	f, err := service.EventServiceApp.ExportEventToXlsx(repo.EventFilter{
 		Offset: 0,
 		Limit:  1000000,
-		Status: input.Status,
+		Status: status,
 		Order:  input.Order,
 	}, input.StartTime, input.EndTime)
 	if err != nil {
@@ -258,10 +266,14 @@ func (er EventRouter) GetClientEventByPage(ctx context.Context, input *GetClient
 	if err != nil {
 		return nil, err
 	}
+	var status []string
+	if input.Status != "" {
+		status = []string{input.Status}
+	}
 	filter := repo.EventFilter{
 		Offset: input.Offset,
 		Limit:  input.Limit,
-		Status: input.Status,
+		Status: status,
 		Order:  input.Order,
 	}
 	events, count, err := service.EventServiceApp.GetClientEventsWithCount(filter, clientId)


### PR DESCRIPTION
Updated the EventFilter struct to support Status as []string instead of string, enabling the public event API to accept:
- No status parameter (empty filter)
- Single status: ?status=open
- Multiple statuses: ?status=open&status=closed

Changes:
- Updated EventFilter.Status from string to []string in repo/event.go
- Modified filtering logic to check len(f.Status) > 0 instead of f.Status != ""
- Updated GetPublicEventByPage to accept []string for status parameter
- Converted string status to []string for other endpoints (GetMemberEventByPage, GetClientEventByPage, ExportEventsToXlsx) to maintain backward compatibility